### PR TITLE
[015-UPDATE_CART] 카트 업데이트

### DIFF
--- a/order-api/src/main/java/com/backend/order/application/CartApplication.java
+++ b/order-api/src/main/java/com/backend/order/application/CartApplication.java
@@ -42,6 +42,13 @@ public class CartApplication {
 
     }
 
+    public Cart updateCart(Long customerId, Cart cart) {
+        // 실질적으로 변하는 데이터
+        // 상품의 삭제, 수량 변경
+        cartService.putCart(customerId, cart);
+        return getCart(customerId);
+    }
+
     // 1. 장바구니에 상품을 추가 했다.
     // 2. 상품의 가격이나 수량이 변동 된다.
     public Cart getCart(Long customerId) {

--- a/order-api/src/main/java/com/backend/order/controller/CustomerCartController.java
+++ b/order-api/src/main/java/com/backend/order/controller/CustomerCartController.java
@@ -29,4 +29,12 @@ public class CustomerCartController {
         return ResponseEntity.ok(cartApplication.getCart(jwtAuthenticationProvider.getUserVo(token).getId()));
     }
 
+    @PutMapping
+    public ResponseEntity<Cart> updateCart(
+            @RequestHeader(name = "X-AUTH-TOKEN") String token,
+            @RequestBody Cart cart) {
+        return ResponseEntity.ok(cartApplication.updateCart(jwtAuthenticationProvider.getUserVo(token).getId(), cart));
+    }
+
+
 }


### PR DESCRIPTION
- 카트 조회 로직을 재사용 -> 코드 생산성을 높였음

- 기존 카트 조회 로직에 가격과 수량, 상품의 삭제 등을 체크하는 로직이 이미 존재해, 이를 호출하여 에러 메세지와 카드의 내용을 업데이트 하는 것으로 적용